### PR TITLE
Add MathJax injection and remove CSS overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+build

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # <img src="public/icons/icon_48.png" width="45" align="left"> Webtex
 
-My Chrome Extension
+Renders LaTeX on any page using a bundled MathJax engine.
 
 ## Features
 
-- Feature 1
-- Feature 2
+- Automatically injects MathJax on every page
+- No external CDN required
 
 ## Install
 

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -55,6 +55,11 @@ const common = {
           from: '**/*',
           context: 'public',
         },
+        {
+          from: '**/*',
+          context: 'node_modules/mathjax/es5',
+          to: 'mathjax'
+        }
       ]
     }),
     // Extract CSS into separate files

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -10,6 +10,7 @@ const config = merge(common, {
   entry: {
     app: PATHS.src + '/app.js',
     background: PATHS.src + '/background.js',
+    content: PATHS.src + '/content.js',
   },
 });
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,8 +24,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["app.js"],
-      "css": ["app.css"],
+      "js": ["content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,22 @@
+(() => {
+  if (window.WebTexMathJaxLoaded) return;
+  window.WebTexMathJaxLoaded = true;
+
+  const config = document.createElement('script');
+  config.type = 'text/javascript';
+  config.textContent = `window.MathJax = {
+    tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+    startup: { typeset: false }
+  };`;
+  document.documentElement.appendChild(config);
+
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = chrome.runtime.getURL('mathjax/tex-mml-chtml.js');
+  script.onload = () => {
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      window.MathJax.typesetPromise();
+    }
+  };
+  document.documentElement.appendChild(script);
+})();


### PR DESCRIPTION
## Summary
- inject MathJax locally via `content.js`
- copy MathJax distribution during build
- remove CSS injection from the content script
- ignore build output
- document the new behaviour in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a2e08475083259bdfc9861e4e56c1