### PR TITLE
Fix CSS injection and load MathJax locally

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -10,6 +10,7 @@ const config = merge(common, {
   entry: {
     app: PATHS.src + '/app.js',
     background: PATHS.src + '/background.js',
+    content: PATHS.src + '/content.js',
   },
 });
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,8 +24,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["app.js"],
-      "css": ["app.css"],
+      "js": ["content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,12 @@
+(async function() {
+  window.MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']]
+    },
+    svg: { fontCache: 'global' }
+  };
+  await import('mathjax/es5/tex-mml-chtml.js');
+  if (window.MathJax && MathJax.typesetPromise) {
+    MathJax.typesetPromise();
+  }
+})();


### PR DESCRIPTION
## Summary
- create a dedicated content script for MathJax
- avoid injecting override CSS into every page
- bundle the new content script in webpack and update manifest

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a2e08475083259bdfc9861e4e56c1