### PR TITLE
Fix nuclear notation pre-processing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -895,6 +895,8 @@ function preprocessMathText(node) {
       // Text node
       let text = child.textContent;
       text = decodeHTMLEntities(text);
+      // Normalize nuclear notation sequences so KaTeX can parse them
+      text = customParser.processNuclearNotation(text);
 
       // Enhanced environment handling
       text = text.replace(


### PR DESCRIPTION
## Summary
- normalize nuclear notation sequences when scanning text nodes
- rebuild extension

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b560fe54c832583747a5a30e0dcc3