### PR TITLE
Fix regex errors in app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1089,7 +1089,7 @@ async function renderMathExpression(tex, displayMode = false, element = null) {
 			reportKaTeXError(tex, katexError);
 
 			// Check if this is an invalid command error
-			const isInvalidCommand = katexError.message && /undefined control sequence|can't use function|unknown function|invalid\\s*command/i.test(katexError.message);
+			const isInvalidCommand = katexError.message && /undefined control sequence|can't use function|unknown function|invalid\s*command/i.test(katexError.message);
 
 			// Try custom parser as fallback
 			try {


### PR DESCRIPTION
Correct regex escaping for whitespace in KaTeX error message detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-38bd142e-b504-4989-b987-8706dff21c02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38bd142e-b504-4989-b987-8706dff21c02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>