### PR TITLE
Fix KaTeX rendering error for math expression

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -616,8 +616,10 @@ class CustomLatexParser {
 		// Fix nuclear notation format: {^{A}} -> {}^{A}
 		str = str.replace(/\{(\^\{[^}]+\})\}/g, "{$1}");
 
-		// Pattern: \text{^{A}\text{N}} -> {}^{A}\text{N}
-		str = str.replace(/\\text\{\\\^\{([^}]+)\}\\text\{([^}]*)\}\}/g, "{}^{$1}\\text{$2}");
+		// Fix nested \text commands in nuclear notation like: \text{^{A}\text{N}} -> {}^{A}\text{N}
+		// This handles malformed input where superscript A and element N are both wrapped in \text{}
+		const MALFORMED_NESTED_TEXT_PATTERN = /\\text\{\\\^\{([^}]+)\}\\text\{([^}]*)\}\}/g;
+		str = str.replace(MALFORMED_NESTED_TEXT_PATTERN, "{}^{$1}\\text{$2}");
 
 		// Final cleanup using the helper method
 		str = cleanupEmptyBraces(str);

--- a/src/app.js
+++ b/src/app.js
@@ -618,7 +618,17 @@ class CustomLatexParser {
 
 		// Fix nested \text commands in nuclear notation like: \text{^{A}\text{N}} -> {}^{A}\text{N}
 		// This handles malformed input where superscript A and element N are both wrapped in \text{}
-		const MALFORMED_NESTED_TEXT_PATTERN = /\\text\{\\\^\{([^}]+)\}\\text\{([^}]*)\}\}/g;
+		// Multi-line, commented regex for maintainability
+		const MALFORMED_NESTED_TEXT_PATTERN = new RegExp(
+			[
+				// Match \text{^{A}\text{N}}
+				String.raw`\\text\{`,           // Match literal \text{
+				String.raw`\\\^\{([^}]+)\}`,    // Match ^{A} (superscript), capture A
+				String.raw`\\text\{([^}]*)\}`,  // Match \text{N}, capture N
+				String.raw`\}`                  // Match closing }
+			].join(''),
+			'g'
+		);
 		str = str.replace(MALFORMED_NESTED_TEXT_PATTERN, "{}^{$1}\\text{$2}");
 
 		// Final cleanup using the helper method

--- a/src/app.js
+++ b/src/app.js
@@ -616,6 +616,9 @@ class CustomLatexParser {
 		// Fix nuclear notation format: {^{A}} -> {}^{A}
 		str = str.replace(/\{(\^\{[^}]+\})\}/g, "{$1}");
 
+		// Pattern: \text{^{A}\text{N}} -> {}^{A}\text{N}
+		str = str.replace(/\\text\{\\\^\{([^}]+)\}\\text\{([^}]*)\}\}/g, "{}^{$1}\\text{$2}");
+
 		// Final cleanup using the helper method
 		str = cleanupEmptyBraces(str);
 


### PR DESCRIPTION
Add a regex to fix a malformed KaTeX nuclear notation pattern, resolving a parse error.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f208dde-1913-445e-b1d4-c188a5aded99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f208dde-1913-445e-b1d4-c188a5aded99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>