### PR TITLE
Fix latex parsing errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -321,6 +321,42 @@ function cleanupEmptyBraces(str) {
 	return str;
 }
 
+// --------------------------------------------------
+// NEW SHARED HELPER: fixIncompleteCommands
+// Centralises fixes for incomplete \text{} commands and malformed integral
+// limits that were previously duplicated in multiple locations.
+function fixIncompleteCommands(str) {
+    // --- Incomplete \text{}
+    // Replace standalone "\\text" at string end or followed by whitespace
+    str = str.replace(/\\text(?=$|\s)/g, "\\text{}");
+
+    // Replace "\\text" not followed by an opening brace
+    str = str.replace(/\\text(?!\s*\{)/g, "\\text{}");
+
+    // Replace "\\text{" that has no closing brace until end-of-string
+    str = str.replace(/\\text\{[^}]*$/g, "\\text{}");
+
+    // --- Malformed integrals (missing superscripts)
+    // \int_{<sub>}^<nothing>
+    str = str.replace(/\\int_\{([^}]+)\}\^\s*$/g, "\\int_{$1}^{}");
+
+    // \int_{<sub>}^  <whitespace>
+    str = str.replace(/\\int_\{([^}]+)\}\^\s+/g, "\\int_{$1}^{} ");
+
+    // \int_{<sub>}^<token>   (token not wrapped in braces)
+    str = str.replace(/\\int_\{([^}]+)\}\^(?!\s*\{)/g, "\\int_{$1}^{}");
+
+    // Also handle variants without braces around subscript, e.g. \int_0^
+    str = str.replace(/\\int_([^\{_\s]+)\^\s*$/g, "\\int_{$1}^{}");
+    str = str.replace(/\\int_([^\{_\s]+)\^(?!\s*\{)/g, "\\int_{$1}^{}");
+
+    // \int_0^{  (missing closing brace on superscript)
+    str = str.replace(/\\int_([^\{_\s]+)\^\{[^}]*$/g, "\\int_{$1}^{}");
+
+    return str;
+}
+// --------------------------------------------------
+
 class CustomLatexParser {
 	constructor() {
 		this.supportedEnvironments = [
@@ -631,6 +667,9 @@ class CustomLatexParser {
 		);
 		str = str.replace(MALFORMED_NESTED_TEXT_PATTERN, "{}^{$1}\\text{$2}");
 
+		// Handle nested form without escaped caret: \text{^{A}\text{N}} -> {}^{A}\text{N}
+		str = str.replace(/\\text\{\^\{([^}]+)\}\\text\{([^}]+)\}\}/g, "{}^{$1}\\text{$2}");
+
 		// Final cleanup using the helper method
 		str = cleanupEmptyBraces(str);
 
@@ -693,22 +732,8 @@ class CustomLatexParser {
 		// Fix missing braces in limits: \lim_{x o infty} -> \lim_{x \to \infty}
 		str = str.replace(/\\lim_\{([^}]*)\s+o\s+infty\}/g, "\\lim_{$1 \\to \\infty}");
 
-		// Fix incomplete \text{} commands
-		str = str.replace(/\\text(?![{\s])/g, "\\text{}");
-		str = str.replace(/\\text$/g, "\\text{}");
-		str = str.replace(/\\text\s+(?!\{)/g, "\\text{} ");
-		// Fix \text{ without closing brace
-		str = str.replace(/\\text\{(?![^}]*\})/g, "\\text{}");
-
-		// Fix malformed integrals with missing superscripts
-		str = str.replace(/\\int_\{([^}]+)\}\^$/g, "\\int_{$1}^{}");
-		str = str.replace(/\\int_\{([^}]+)\}\^\s/g, "\\int_{$1}^{} ");
-		str = str.replace(/\\int_\{([^}]+)\}\^(?!\{)/g, "\\int_{$1}^{}");
-		// Also handle \int_0^ style (without braces around subscript)
-		str = str.replace(/\\int_([^{_\s]+)\^$/g, "\\int_{$1}^{}");
-		str = str.replace(/\\int_([^{_\s]+)\^(?!\{)/g, "\\int_{$1}^{}");
-		// Fix \int_0^{ without closing brace
-		str = str.replace(/\\int_([^{_\s]+)\^\{(?![^}]*\})/g, "\\int_{$1}^{}");
+		// Delegate incomplete command and integral fixes to shared helper
+		str = fixIncompleteCommands(str);
 
 		// Auto-wrap bare ^ and _ arguments with braces
 		str = str.replace(/(\^|_)(?![{\\])\s*([A-Za-z0-9+-])/g, "$1{$2}");
@@ -798,7 +823,7 @@ class CustomLatexParser {
 
 const customParser = new CustomLatexParser();
 
-// -------------------------------------------------- */
+/* -------------------------------------------------- */
 // Enhanced delimiter balance check with LaTeX-specific handling
 function hasUnbalancedDelimiters(str) {
 	// Skip empty or very short strings
@@ -1018,22 +1043,8 @@ async function renderMathExpression(tex, displayMode = false, element = null) {
 		console.log("[WebTeX Debug] Fixing malformed integral in:", prefixedTex);
 	}
 
-	// Fix incomplete \text{} commands
-	prefixedTex = prefixedTex.replace(/\\text(?![{\s])/g, "\\text{}");
-	prefixedTex = prefixedTex.replace(/\\text$/g, "\\text{}");
-	prefixedTex = prefixedTex.replace(/\\text\s+(?!\{)/g, "\\text{} ");
-	// Fix \text{ without closing brace
-	prefixedTex = prefixedTex.replace(/\\text\{(?![^}]*\})/g, "\\text{}");
-
-	// Fix malformed integrals with missing superscripts
-	prefixedTex = prefixedTex.replace(/\\int_\{([^}]+)\}\^$/g, "\\int_{$1}^{}");
-	prefixedTex = prefixedTex.replace(/\\int_\{([^}]+)\}\^\s/g, "\\int_{$1}^{} ");
-	prefixedTex = prefixedTex.replace(/\\int_\{([^}]+)\}\^(?!\{)/g, "\\int_{$1}^{}");
-	// Also handle \int_0^ style (without braces around subscript)
-	prefixedTex = prefixedTex.replace(/\\int_([^{_\s]+)\^$/g, "\\int_{$1}^{}");
-	prefixedTex = prefixedTex.replace(/\\int_([^{_\s]+)\^(?!\{)/g, "\\int_{$1}^{}");
-	// Fix \int_0^{ without closing brace
-	prefixedTex = prefixedTex.replace(/\\int_([^{_\s]+)\^\{(?![^}]*\})/g, "\\int_{$1}^{}");
+	// Apply shared fixes for incomplete commands and malformed integrals
+	prefixedTex = fixIncompleteCommands(prefixedTex);
 
 	// Debug: log the result after fixes
 	if (cleanedTex !== prefixedTex) {


### PR DESCRIPTION
Fix KaTeX parse errors for `\text{}` and `\int` commands and nuclear notation by centralizing and improving LaTeX parsing regexes.

The original regex patterns for fixing incomplete `\text{}` and `\int` commands were duplicated and used a fragile negative lookahead `(?![^}]*\})` that often failed. This PR introduces a shared helper function `fixIncompleteCommands` with more robust regexes to correctly handle these cases, and adds a specific fix for malformed nuclear notation within `\text{}`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf3f222c-8ecb-4b12-a894-560bd62c3af0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf3f222c-8ecb-4b12-a894-560bd62c3af0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>